### PR TITLE
Apache2 vhost file needs to end in .conf, bump to 0.4.6

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@hw-ops.com'
 license          'Apache 2.0'
 description      'Installs/Configures graphite'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.5'
+version          '0.4.6'
 
 supports 'ubuntu'
 supports 'debian'

--- a/recipes/apache.rb
+++ b/recipes/apache.rb
@@ -7,7 +7,7 @@ execute 'create apache basic_auth file for graphite' do
   only_if { node['graphite']['apache']['basic_auth']['enabled'] }
 end
 
-template "#{node['apache']['dir']}/sites-available/graphite" do
+template "#{node['apache']['dir']}/sites-available/graphite.conf" do
   source 'graphite-vhost.conf.erb'
   notifies :reload, 'service[apache2]'
 end


### PR DESCRIPTION
This is required for newer versions of the apache2 cookbook, see COOK-3570:

  https://tickets.opscode.com/browse/COOK-3570